### PR TITLE
Increase resource quota for controller-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,8 +49,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 128Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 128Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The controller-manager is crashing frequently, stating an OOM kill as cause.

Increasing the granted resource to equal the ones set in the similar install trough helm: https://github.com/Aaqua-live/flink-on-k8s-operator/blob/master/helm-chart/flink-operator/values.yaml#L41